### PR TITLE
ported changes from recent TCCE update

### DIFF
--- a/src/main/java/com/jcirmodelsquad/tcjcir/blocks/BlockMILWSwitchStand.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/blocks/BlockMILWSwitchStand.java
@@ -3,6 +3,7 @@ package com.jcirmodelsquad.tcjcir.blocks;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockLever;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -23,11 +24,11 @@ import com.jcirmodelsquad.tcjcir.tile.TileMILWSwitchStand;
 import java.util.List;
 import java.util.Random;
 
-public class BlockMILWSwitchStand extends Block {
+public class BlockMILWSwitchStand extends BlockLever {
 	private IIcon texture;
 
 	public BlockMILWSwitchStand() {
-		super(Material.rock);
+		super();
 		setCreativeTab(Traincraft.tcTab);
 		this.setTickRandomly(true);
 		//this.setBlockBounds(0.5F , 0.0F, 0.5F , 0.5F ,  2.0F, 0.5F);
@@ -83,114 +84,6 @@ public class BlockMILWSwitchStand extends Block {
 			world.markBlockForUpdate(i, j, k);
 		}
 	}
-	public boolean onBlockActivated(World p_149727_1_, int p_149727_2_, int p_149727_3_, int p_149727_4_, EntityPlayer p_149727_5_, int p_149727_6_, float p_149727_7_, float p_149727_8_, float p_149727_9_)
-	{
-		if (p_149727_1_.isRemote)
-		{
-			return true;
-		}
-		else
-		{
-			int i1 = p_149727_1_.getBlockMetadata(p_149727_2_, p_149727_3_, p_149727_4_);
-			int j1 = i1 & 7;
-			int k1 = 8 - (i1 & 8);
-			p_149727_1_.setBlockMetadataWithNotify(p_149727_2_, p_149727_3_, p_149727_4_, j1 + k1, 3);
-			p_149727_1_.playSoundEffect((double)p_149727_2_ + 0.5D, (double)p_149727_3_ + 0.5D, (double)p_149727_4_ + 0.5D, "random.click", 0.3F, k1 > 0 ? 0.6F : 0.5F);
-			p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_, this);
-
-			if (j1 == 1)
-			{
-				p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ - 1, p_149727_3_, p_149727_4_, this);
-			}
-			else if (j1 == 2)
-			{
-				p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ + 1, p_149727_3_, p_149727_4_, this);
-			}
-			else if (j1 == 3)
-			{
-				p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ - 1, this);
-			}
-			else if (j1 == 4)
-			{
-				p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ + 1, this);
-			}
-			else if (j1 != 5 && j1 != 6)
-			{
-				if (j1 == 0 || j1 == 7)
-				{
-					p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ + 1, p_149727_4_, this);
-				}
-			}
-			else
-			{
-				p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ - 1, p_149727_4_, this);
-			}
-
-			return true;
-		}
-	}
-
-	public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
-	{
-		if ((p_149749_6_ & 8) > 0)
-		{
-			p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_, this);
-			int i1 = p_149749_6_ & 7;
-
-			if (i1 == 1)
-			{
-				p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ - 1, p_149749_3_, p_149749_4_, this);
-			}
-			else if (i1 == 2)
-			{
-				p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ + 1, p_149749_3_, p_149749_4_, this);
-			}
-			else if (i1 == 3)
-			{
-				p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ - 1, this);
-			}
-			else if (i1 == 4)
-			{
-				p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ + 1, this);
-			}
-			else if (i1 != 5 && i1 != 6)
-			{
-				if (i1 == 0 || i1 == 7)
-				{
-					p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ + 1, p_149749_4_, this);
-				}
-			}
-			else
-			{
-				p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ - 1, p_149749_4_, this);
-			}
-		}
-
-		super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
-	}
-
-
-
-	public int isProvidingWeakPower(IBlockAccess p_149709_1_, int p_149709_2_, int p_149709_3_, int p_149709_4_, int p_149709_5_)
-	{
-		return (p_149709_1_.getBlockMetadata(p_149709_2_, p_149709_3_, p_149709_4_) & 8) > 0 ? 15 : 0;
-	}
-
-	public int isProvidingStrongPower(IBlockAccess p_149748_1_, int p_149748_2_, int p_149748_3_, int p_149748_4_, int p_149748_5_)
-	{
-		int i1 = p_149748_1_.getBlockMetadata(p_149748_2_, p_149748_3_, p_149748_4_);
-
-		if ((i1 & 8) == 0)
-		{
-			return 0;
-		}
-		else
-		{
-			int j1 = i1 & 7;
-			return j1 == 0 && p_149748_5_ == 0 ? 15 : (j1 == 7 && p_149748_5_ == 0 ? 15 : (j1 == 6 && p_149748_5_ == 1 ? 15 : (j1 == 5 && p_149748_5_ == 1 ? 15 : (j1 == 4 && p_149748_5_ == 2 ? 15 : (j1 == 3 && p_149748_5_ == 3 ? 15 : (j1 == 2 && p_149748_5_ == 4 ? 15 : (j1 == 1 && p_149748_5_ == 5 ? 15 : 0)))))));
-		}
-	}
-
 	/**
 	 * Can this block provide power. Only wire currently seems to have this change based on its state.
 	 */

--- a/src/main/java/com/jcirmodelsquad/tcjcir/blocks/BlockautoSwitchStand.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/blocks/BlockautoSwitchStand.java
@@ -3,6 +3,7 @@ package com.jcirmodelsquad.tcjcir.blocks;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockLever;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -23,11 +24,11 @@ import com.jcirmodelsquad.tcjcir.tile.TileautoSwitchStand;
 import java.util.List;
 import java.util.Random;
 
-public class BlockautoSwitchStand extends Block {
+public class BlockautoSwitchStand extends BlockLever {
     private IIcon texture;
 
     public BlockautoSwitchStand() {
-        super(Material.rock);
+        super();
         setCreativeTab(Traincraft.tcTab);
         this.setTickRandomly(true);
         //this.setBlockBounds(0.5F , 0.0F, 0.5F , 0.5F ,  2.0F, 0.5F);
@@ -81,113 +82,6 @@ public class BlockautoSwitchStand extends Block {
             int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
             world.markBlockForUpdate(i, j, k);
-        }
-    }
-    public boolean onBlockActivated(World p_149727_1_, int p_149727_2_, int p_149727_3_, int p_149727_4_, EntityPlayer p_149727_5_, int p_149727_6_, float p_149727_7_, float p_149727_8_, float p_149727_9_)
-    {
-        if (p_149727_1_.isRemote)
-        {
-            return true;
-        }
-        else
-        {
-            int i1 = p_149727_1_.getBlockMetadata(p_149727_2_, p_149727_3_, p_149727_4_);
-            int j1 = i1 & 7;
-            int k1 = 8 - (i1 & 8);
-            p_149727_1_.setBlockMetadataWithNotify(p_149727_2_, p_149727_3_, p_149727_4_, j1 + k1, 3);
-            p_149727_1_.playSoundEffect((double)p_149727_2_ + 0.5D, (double)p_149727_3_ + 0.5D, (double)p_149727_4_ + 0.5D, "random.click", 0.3F, k1 > 0 ? 0.6F : 0.5F);
-            p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_, this);
-
-            if (j1 == 1)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ - 1, p_149727_3_, p_149727_4_, this);
-            }
-            else if (j1 == 2)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ + 1, p_149727_3_, p_149727_4_, this);
-            }
-            else if (j1 == 3)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ - 1, this);
-            }
-            else if (j1 == 4)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ + 1, this);
-            }
-            else if (j1 != 5 && j1 != 6)
-            {
-                if (j1 == 0 || j1 == 7)
-                {
-                    p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ + 1, p_149727_4_, this);
-                }
-            }
-            else
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ - 1, p_149727_4_, this);
-            }
-
-            return true;
-        }
-    }
-
-    public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
-    {
-        if ((p_149749_6_ & 8) > 0)
-        {
-            p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_, this);
-            int i1 = p_149749_6_ & 7;
-
-            if (i1 == 1)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ - 1, p_149749_3_, p_149749_4_, this);
-            }
-            else if (i1 == 2)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ + 1, p_149749_3_, p_149749_4_, this);
-            }
-            else if (i1 == 3)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ - 1, this);
-            }
-            else if (i1 == 4)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ + 1, this);
-            }
-            else if (i1 != 5 && i1 != 6)
-            {
-                if (i1 == 0 || i1 == 7)
-                {
-                    p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ + 1, p_149749_4_, this);
-                }
-            }
-            else
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ - 1, p_149749_4_, this);
-            }
-        }
-
-        super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
-    }
-
-
-
-    public int isProvidingWeakPower(IBlockAccess p_149709_1_, int p_149709_2_, int p_149709_3_, int p_149709_4_, int p_149709_5_)
-    {
-        return (p_149709_1_.getBlockMetadata(p_149709_2_, p_149709_3_, p_149709_4_) & 8) > 0 ? 15 : 0;
-    }
-
-    public int isProvidingStrongPower(IBlockAccess p_149748_1_, int p_149748_2_, int p_149748_3_, int p_149748_4_, int p_149748_5_)
-    {
-        int i1 = p_149748_1_.getBlockMetadata(p_149748_2_, p_149748_3_, p_149748_4_);
-
-        if ((i1 & 8) == 0)
-        {
-            return 0;
-        }
-        else
-        {
-            int j1 = i1 & 7;
-            return j1 == 0 && p_149748_5_ == 0 ? 15 : (j1 == 7 && p_149748_5_ == 0 ? 15 : (j1 == 6 && p_149748_5_ == 1 ? 15 : (j1 == 5 && p_149748_5_ == 1 ? 15 : (j1 == 4 && p_149748_5_ == 2 ? 15 : (j1 == 3 && p_149748_5_ == 3 ? 15 : (j1 == 2 && p_149748_5_ == 4 ? 15 : (j1 == 1 && p_149748_5_ == 5 ? 15 : 0)))))));
         }
     }
 

--- a/src/main/java/com/jcirmodelsquad/tcjcir/blocks/BlockcircleSwitchStand.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/blocks/BlockcircleSwitchStand.java
@@ -3,6 +3,7 @@ package com.jcirmodelsquad.tcjcir.blocks;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockLever;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -23,11 +24,11 @@ import com.jcirmodelsquad.tcjcir.tile.TilecircleSwitchStand;
 import java.util.List;
 import java.util.Random;
 
-public class BlockcircleSwitchStand extends Block {
+public class BlockcircleSwitchStand extends BlockLever {
     private IIcon texture;
 
     public BlockcircleSwitchStand() {
-        super(Material.rock);
+        super();
         setCreativeTab(Traincraft.tcTab);
         this.setTickRandomly(true);
         //this.setBlockBounds(0.5F , 0.0F, 0.5F , 0.5F ,  2.0F, 0.5F);
@@ -81,113 +82,6 @@ public class BlockcircleSwitchStand extends Block {
             int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
             world.markBlockForUpdate(i, j, k);
-        }
-    }
-    public boolean onBlockActivated(World p_149727_1_, int p_149727_2_, int p_149727_3_, int p_149727_4_, EntityPlayer p_149727_5_, int p_149727_6_, float p_149727_7_, float p_149727_8_, float p_149727_9_)
-    {
-        if (p_149727_1_.isRemote)
-        {
-            return true;
-        }
-        else
-        {
-            int i1 = p_149727_1_.getBlockMetadata(p_149727_2_, p_149727_3_, p_149727_4_);
-            int j1 = i1 & 7;
-            int k1 = 8 - (i1 & 8);
-            p_149727_1_.setBlockMetadataWithNotify(p_149727_2_, p_149727_3_, p_149727_4_, j1 + k1, 3);
-            p_149727_1_.playSoundEffect((double)p_149727_2_ + 0.5D, (double)p_149727_3_ + 0.5D, (double)p_149727_4_ + 0.5D, "random.click", 0.3F, k1 > 0 ? 0.6F : 0.5F);
-            p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_, this);
-
-            if (j1 == 1)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ - 1, p_149727_3_, p_149727_4_, this);
-            }
-            else if (j1 == 2)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ + 1, p_149727_3_, p_149727_4_, this);
-            }
-            else if (j1 == 3)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ - 1, this);
-            }
-            else if (j1 == 4)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ + 1, this);
-            }
-            else if (j1 != 5 && j1 != 6)
-            {
-                if (j1 == 0 || j1 == 7)
-                {
-                    p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ + 1, p_149727_4_, this);
-                }
-            }
-            else
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ - 1, p_149727_4_, this);
-            }
-
-            return true;
-        }
-    }
-
-    public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
-    {
-        if ((p_149749_6_ & 8) > 0)
-        {
-            p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_, this);
-            int i1 = p_149749_6_ & 7;
-
-            if (i1 == 1)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ - 1, p_149749_3_, p_149749_4_, this);
-            }
-            else if (i1 == 2)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ + 1, p_149749_3_, p_149749_4_, this);
-            }
-            else if (i1 == 3)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ - 1, this);
-            }
-            else if (i1 == 4)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ + 1, this);
-            }
-            else if (i1 != 5 && i1 != 6)
-            {
-                if (i1 == 0 || i1 == 7)
-                {
-                    p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ + 1, p_149749_4_, this);
-                }
-            }
-            else
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ - 1, p_149749_4_, this);
-            }
-        }
-
-        super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
-    }
-
-
-
-    public int isProvidingWeakPower(IBlockAccess p_149709_1_, int p_149709_2_, int p_149709_3_, int p_149709_4_, int p_149709_5_)
-    {
-        return (p_149709_1_.getBlockMetadata(p_149709_2_, p_149709_3_, p_149709_4_) & 8) > 0 ? 15 : 0;
-    }
-
-    public int isProvidingStrongPower(IBlockAccess p_149748_1_, int p_149748_2_, int p_149748_3_, int p_149748_4_, int p_149748_5_)
-    {
-        int i1 = p_149748_1_.getBlockMetadata(p_149748_2_, p_149748_3_, p_149748_4_);
-
-        if ((i1 & 8) == 0)
-        {
-            return 0;
-        }
-        else
-        {
-            int j1 = i1 & 7;
-            return j1 == 0 && p_149748_5_ == 0 ? 15 : (j1 == 7 && p_149748_5_ == 0 ? 15 : (j1 == 6 && p_149748_5_ == 1 ? 15 : (j1 == 5 && p_149748_5_ == 1 ? 15 : (j1 == 4 && p_149748_5_ == 2 ? 15 : (j1 == 3 && p_149748_5_ == 3 ? 15 : (j1 == 2 && p_149748_5_ == 4 ? 15 : (j1 == 1 && p_149748_5_ == 5 ? 15 : 0)))))));
         }
     }
 

--- a/src/main/java/com/jcirmodelsquad/tcjcir/blocks/BlockowoSwitchStand.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/blocks/BlockowoSwitchStand.java
@@ -3,6 +3,7 @@ package com.jcirmodelsquad.tcjcir.blocks;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockLever;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -23,11 +24,11 @@ import com.jcirmodelsquad.tcjcir.tile.TileowoSwitchStand;
 import java.util.List;
 import java.util.Random;
 
-public class BlockowoSwitchStand extends Block {
+public class BlockowoSwitchStand extends BlockLever {
     private IIcon texture;
 
     public BlockowoSwitchStand() {
-        super(Material.rock);
+        super();
         setCreativeTab(Traincraft.tcTab);
         this.setTickRandomly(true);
         //this.setBlockBounds(0.5F , 0.0F, 0.5F , 0.5F ,  2.0F, 0.5F);
@@ -81,113 +82,6 @@ public class BlockowoSwitchStand extends Block {
             int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
             world.markBlockForUpdate(i, j, k);
-        }
-    }
-    public boolean onBlockActivated(World p_149727_1_, int p_149727_2_, int p_149727_3_, int p_149727_4_, EntityPlayer p_149727_5_, int p_149727_6_, float p_149727_7_, float p_149727_8_, float p_149727_9_)
-    {
-        if (p_149727_1_.isRemote)
-        {
-            return true;
-        }
-        else
-        {
-            int i1 = p_149727_1_.getBlockMetadata(p_149727_2_, p_149727_3_, p_149727_4_);
-            int j1 = i1 & 7;
-            int k1 = 8 - (i1 & 8);
-            p_149727_1_.setBlockMetadataWithNotify(p_149727_2_, p_149727_3_, p_149727_4_, j1 + k1, 3);
-            p_149727_1_.playSoundEffect((double)p_149727_2_ + 0.5D, (double)p_149727_3_ + 0.5D, (double)p_149727_4_ + 0.5D, "random.click", 0.3F, k1 > 0 ? 0.6F : 0.5F);
-            p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_, this);
-
-            if (j1 == 1)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ - 1, p_149727_3_, p_149727_4_, this);
-            }
-            else if (j1 == 2)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ + 1, p_149727_3_, p_149727_4_, this);
-            }
-            else if (j1 == 3)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ - 1, this);
-            }
-            else if (j1 == 4)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ + 1, this);
-            }
-            else if (j1 != 5 && j1 != 6)
-            {
-                if (j1 == 0 || j1 == 7)
-                {
-                    p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ + 1, p_149727_4_, this);
-                }
-            }
-            else
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ - 1, p_149727_4_, this);
-            }
-
-            return true;
-        }
-    }
-
-    public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
-    {
-        if ((p_149749_6_ & 8) > 0)
-        {
-            p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_, this);
-            int i1 = p_149749_6_ & 7;
-
-            if (i1 == 1)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ - 1, p_149749_3_, p_149749_4_, this);
-            }
-            else if (i1 == 2)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ + 1, p_149749_3_, p_149749_4_, this);
-            }
-            else if (i1 == 3)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ - 1, this);
-            }
-            else if (i1 == 4)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ + 1, this);
-            }
-            else if (i1 != 5 && i1 != 6)
-            {
-                if (i1 == 0 || i1 == 7)
-                {
-                    p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ + 1, p_149749_4_, this);
-                }
-            }
-            else
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ - 1, p_149749_4_, this);
-            }
-        }
-
-        super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
-    }
-
-
-
-    public int isProvidingWeakPower(IBlockAccess p_149709_1_, int p_149709_2_, int p_149709_3_, int p_149709_4_, int p_149709_5_)
-    {
-        return (p_149709_1_.getBlockMetadata(p_149709_2_, p_149709_3_, p_149709_4_) & 8) > 0 ? 15 : 0;
-    }
-
-    public int isProvidingStrongPower(IBlockAccess p_149748_1_, int p_149748_2_, int p_149748_3_, int p_149748_4_, int p_149748_5_)
-    {
-        int i1 = p_149748_1_.getBlockMetadata(p_149748_2_, p_149748_3_, p_149748_4_);
-
-        if ((i1 & 8) == 0)
-        {
-            return 0;
-        }
-        else
-        {
-            int j1 = i1 & 7;
-            return j1 == 0 && p_149748_5_ == 0 ? 15 : (j1 == 7 && p_149748_5_ == 0 ? 15 : (j1 == 6 && p_149748_5_ == 1 ? 15 : (j1 == 5 && p_149748_5_ == 1 ? 15 : (j1 == 4 && p_149748_5_ == 2 ? 15 : (j1 == 3 && p_149748_5_ == 3 ? 15 : (j1 == 2 && p_149748_5_ == 4 ? 15 : (j1 == 1 && p_149748_5_ == 5 ? 15 : 0)))))));
         }
     }
 

--- a/src/main/java/com/jcirmodelsquad/tcjcir/blocks/BlockowoYardSwitchStand.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/blocks/BlockowoYardSwitchStand.java
@@ -4,6 +4,7 @@ import com.jcirmodelsquad.tcjcir.tile.TileowoYardSwitchStand;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockLever;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -24,11 +25,11 @@ import com.jcirmodelsquad.tcjcir.tile.TileowoYardSwitchStand;
 import java.util.List;
 import java.util.Random;
 
-public class BlockowoYardSwitchStand extends Block {
+public class BlockowoYardSwitchStand extends BlockLever {
     private IIcon texture;
 
     public BlockowoYardSwitchStand() {
-        super(Material.rock);
+        super();
         setCreativeTab(Traincraft.tcTab);
         this.setTickRandomly(true);
         //this.setBlockBounds(0.5F , 0.0F, 0.5F , 0.5F ,  2.0F, 0.5F);
@@ -82,113 +83,6 @@ public class BlockowoYardSwitchStand extends Block {
             int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
             world.markBlockForUpdate(i, j, k);
-        }
-    }
-    public boolean onBlockActivated(World p_149727_1_, int p_149727_2_, int p_149727_3_, int p_149727_4_, EntityPlayer p_149727_5_, int p_149727_6_, float p_149727_7_, float p_149727_8_, float p_149727_9_)
-    {
-        if (p_149727_1_.isRemote)
-        {
-            return true;
-        }
-        else
-        {
-            int i1 = p_149727_1_.getBlockMetadata(p_149727_2_, p_149727_3_, p_149727_4_);
-            int j1 = i1 & 7;
-            int k1 = 8 - (i1 & 8);
-            p_149727_1_.setBlockMetadataWithNotify(p_149727_2_, p_149727_3_, p_149727_4_, j1 + k1, 3);
-            p_149727_1_.playSoundEffect((double)p_149727_2_ + 0.5D, (double)p_149727_3_ + 0.5D, (double)p_149727_4_ + 0.5D, "random.click", 0.3F, k1 > 0 ? 0.6F : 0.5F);
-            p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_, this);
-
-            if (j1 == 1)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ - 1, p_149727_3_, p_149727_4_, this);
-            }
-            else if (j1 == 2)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ + 1, p_149727_3_, p_149727_4_, this);
-            }
-            else if (j1 == 3)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ - 1, this);
-            }
-            else if (j1 == 4)
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ + 1, this);
-            }
-            else if (j1 != 5 && j1 != 6)
-            {
-                if (j1 == 0 || j1 == 7)
-                {
-                    p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ + 1, p_149727_4_, this);
-                }
-            }
-            else
-            {
-                p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ - 1, p_149727_4_, this);
-            }
-
-            return true;
-        }
-    }
-
-    public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
-    {
-        if ((p_149749_6_ & 8) > 0)
-        {
-            p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_, this);
-            int i1 = p_149749_6_ & 7;
-
-            if (i1 == 1)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ - 1, p_149749_3_, p_149749_4_, this);
-            }
-            else if (i1 == 2)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ + 1, p_149749_3_, p_149749_4_, this);
-            }
-            else if (i1 == 3)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ - 1, this);
-            }
-            else if (i1 == 4)
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ + 1, this);
-            }
-            else if (i1 != 5 && i1 != 6)
-            {
-                if (i1 == 0 || i1 == 7)
-                {
-                    p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ + 1, p_149749_4_, this);
-                }
-            }
-            else
-            {
-                p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ - 1, p_149749_4_, this);
-            }
-        }
-
-        super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
-    }
-
-
-
-    public int isProvidingWeakPower(IBlockAccess p_149709_1_, int p_149709_2_, int p_149709_3_, int p_149709_4_, int p_149709_5_)
-    {
-        return (p_149709_1_.getBlockMetadata(p_149709_2_, p_149709_3_, p_149709_4_) & 8) > 0 ? 15 : 0;
-    }
-
-    public int isProvidingStrongPower(IBlockAccess p_149748_1_, int p_149748_2_, int p_149748_3_, int p_149748_4_, int p_149748_5_)
-    {
-        int i1 = p_149748_1_.getBlockMetadata(p_149748_2_, p_149748_3_, p_149748_4_);
-
-        if ((i1 & 8) == 0)
-        {
-            return 0;
-        }
-        else
-        {
-            int j1 = i1 & 7;
-            return j1 == 0 && p_149748_5_ == 0 ? 15 : (j1 == 7 && p_149748_5_ == 0 ? 15 : (j1 == 6 && p_149748_5_ == 1 ? 15 : (j1 == 5 && p_149748_5_ == 1 ? 15 : (j1 == 4 && p_149748_5_ == 2 ? 15 : (j1 == 3 && p_149748_5_ == 3 ? 15 : (j1 == 2 && p_149748_5_ == 4 ? 15 : (j1 == 1 && p_149748_5_ == 5 ? 15 : 0)))))));
         }
     }
 

--- a/src/main/java/train/common/adminbook/GUIAdminBook.java
+++ b/src/main/java/train/common/adminbook/GUIAdminBook.java
@@ -77,6 +77,13 @@ public class GUIAdminBook extends GuiScreen {
                 initGui();
                 break;
             }
+            case 3:{
+                if(list[0]!=null && list[0].length()>1) {
+                    Traincraft.keyChannel.sendToServer(new ItemAdminBook.PacketAdminBookClient("0:" + list[0].substring(1), Minecraft.getMinecraft().thePlayer.getEntityId()));//tell server to drop items
+                    Traincraft.keyChannel.sendToServer(new ItemAdminBook.PacketAdminBookClient("1:" + list[0].substring(1), Minecraft.getMinecraft().thePlayer.getEntityId()));//tell server to drop items
+                }
+                break;
+            }
             default:{
                 Traincraft.keyChannel.sendToServer(new ItemAdminBook.PacketAdminBookClient( list[button.id-3], Minecraft.getMinecraft().thePlayer.getEntityId()));//tell server to send a new gui
                 break;
@@ -118,8 +125,9 @@ public class GUIAdminBook extends GuiScreen {
         } else {
             try {
                 //draw back
-                this.buttonList.add(new GuiButton(-1,guiLeft+80,guiTop+140,120,20,"clone inventory"));
-                this.buttonList.add(new GuiButton(0,guiLeft+10,guiTop+140,70,20,"delete entry"));
+                this.buttonList.add(new GuiButton(-1,guiLeft+85,guiTop+140,90,20,"clone inventory"));
+                this.buttonList.add(new GuiButton(0,guiLeft+5,guiTop+140,70,20,"delete entry"));
+                this.buttonList.add(new GuiButton(3,guiLeft+180,guiTop+140,80,20,"clone & delete"));
                 this.buttonList.add(new GuiButton(1, guiLeft-70, guiTop+140 , 70, 20, "back"));
                 items = ServerLogger.getItems(list[9]);
             } catch (Exception e){}

--- a/src/main/java/train/common/api/AbstractTrains.java
+++ b/src/main/java/train/common/api/AbstractTrains.java
@@ -128,11 +128,6 @@ public abstract class AbstractTrains extends EntityMinecart implements IMinecart
 	public static int uniqueIDs = 1;
 
 	/**
-	 * cached value for the render data so we don't have to iterate the enum every frame.
-	 */
-	public RenderEnum renderData = null;
-
-	/**
 	 * The distance this train has traveled
 	 */
 	public double trainDistanceTraveled = 0;
@@ -196,11 +191,22 @@ public abstract class AbstractTrains extends EntityMinecart implements IMinecart
 
 	@Override
 	public AxisAlignedBB getCollisionBox(Entity p_70114_1_) {
-		if(riddenByEntity!=p_70114_1_){
-			return super.getCollisionBox(p_70114_1_);
-		} else {
+		if(riddenByEntity==p_70114_1_){
 			return null;
 		}
+		if (getCollisionHandler() != null) {
+			return getCollisionHandler().getCollisionBox(this, p_70114_1_);
+		}
+		return p_70114_1_.boundingBox;
+	}
+	@Override
+	public AxisAlignedBB getBoundingBox() {
+		if (getCollisionHandler() != null) {
+			return getCollisionHandler().getBoundingBox(this);
+		}
+		return AxisAlignedBB.getBoundingBox(
+				posX-0.5,posY,posZ-0.5,
+				posX+0.5, posY+2, posZ+0.5);
 	}
 	/**
 	 * this is basically NBT for entity spawn, to keep data between client and server in sync because some data is not automatically shared.
@@ -622,8 +628,13 @@ public abstract class AbstractTrains extends EntityMinecart implements IMinecart
 		if (!isCreative && !itemdropped) {
 			itemdropped=true;
 			for (ItemStack item : getItemsDropped()) {
-				setUniqueIDToItem(item);
-				entityDropItem(item, 0);
+				if (item.getItem() instanceof ItemRollingStock){
+					ItemStack stack = ItemRollingStock.setPersistentData(item,this,this.getUniqueTrainID(),trainCreator, trainOwner, getColor());
+					entityDropItem(stack!=null?stack:item,0);
+				} else {
+					setUniqueIDToItem(item);
+					entityDropItem(item, 0);
+				}
 			}
 		}
 	}
@@ -722,7 +733,7 @@ public abstract class AbstractTrains extends EntityMinecart implements IMinecart
 	public boolean doesCartMatchFilter(ItemStack stack, EntityMinecart cart) {
 		if (stack == null || cart == null) { return false; }
 		ItemStack cartItem = cart.getCartItem();
-		return cartItem != null && stack.isItemEqual(cartItem);
+		return cartItem.getItem() == stack.getItem();
 	}
 
 	@Override
@@ -775,5 +786,16 @@ public abstract class AbstractTrains extends EntityMinecart implements IMinecart
 			this.setTicket(chunkTicket);
 		}
 	}
+
+	public String getPersistentUUID() {
+		if(getEntityData().hasKey("puuid")) {
+			return getEntityData().getString("puuid");
+		} else {
+			System.out.println("setting UUID");
+			getEntityData().setString("puuid", getUniqueID().toString());
+			return this.getUniqueID().toString();
+		}
+	}
+
 
 }

--- a/src/main/java/train/common/api/EntityBogie.java
+++ b/src/main/java/train/common/api/EntityBogie.java
@@ -81,6 +81,7 @@ public class EntityBogie extends EntityMinecart implements IMinecart, IRoutableC
 		this.yOffset = 0.65f;
 		//this.setSize(0.1F, 1.98F);
 		this.side = FMLCommonHandler.instance().getEffectiveSide();
+		isImmuneToFire = true;
 	}
 
 	public EntityBogie(World world, double d, double d1, double d2, EntityRollingStock mainTrain, int id, int index, double bogieShift) {
@@ -98,6 +99,7 @@ public class EntityBogie extends EntityMinecart implements IMinecart, IRoutableC
 		this.bogieIndex = index;
 		this.bogieShift = bogieShift;
 		this.setPosition(d, d1 + this.yOffset, d2);
+		isImmuneToFire = true;
 	}
 
 	@Override
@@ -243,8 +245,9 @@ public class EntityBogie extends EntityMinecart implements IMinecart, IRoutableC
 	
 	private boolean isDerail = false;
 	public boolean isOnRail(){
-		if(isDerail)
+		if(isDerail) {
 			return false;
+		}
 		
 		int i = MathHelper.floor_double(this.posX);
 		int j = MathHelper.floor_double(this.posY);

--- a/src/main/java/train/common/api/EntityRollingStock.java
+++ b/src/main/java/train/common/api/EntityRollingStock.java
@@ -69,9 +69,6 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 
 	protected EntityPlayer playerEntity;
 
-	/** Axis aligned bounding box. */
-	private AxisAlignedBB boundingBoxSmall;
-
 
 	public float maxSpeed;
 	public float railMaxSpeed;
@@ -197,9 +194,9 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 
 		entityCollisionReduction = 0.8F;
 
-		boundingBoxSmall = AxisAlignedBB.getBoundingBox(0.0D, 0.0D, 0.0D, 0.0D, 2.0D, 1.0D);
+		//boundingBoxSmall = AxisAlignedBB.getBoundingBox(0.0D, 0.0D, 0.0D, 0.0D, 2.0D, 1.0D);
 		//setBoundingBoxSmall(0.0D, 0.0D, 0.0D, 0.98F, 0.7F);
-		setBoundingBoxSmall(0.0D, 0.0D, 0.0D, 2.0F, 1.0F);
+		setBoundingBoxSmall(0.0D, 0.0D, 0.0D, 2.0F, 1.5F);
 		RollingStock = new ArrayList<EntityRollingStock>();
 		handleOverheating = new HandleOverheating(this);
 
@@ -923,12 +920,13 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 		if (list != null && !list.isEmpty()) {
 			Entity entity;
 			for (Object obj : list) {
+				if(obj==this.riddenByEntity){continue;}
 				entity = (Entity) obj;
 
-				if (entity != this.riddenByEntity && entity.canBePushed() && entity instanceof EntityMinecart) {
+				if (entity.canBePushed() && entity instanceof EntityMinecart) {
 					entity.applyEntityCollision(this);
 				}
-				else if (entity != this.riddenByEntity && entity.canBePushed() && !(entity instanceof EntityMinecart)) {
+				else if (entity.canBePushed() && !(entity instanceof EntityMinecart)) {
 					this.applyEntityCollision(entity);
 				}
 			}
@@ -971,7 +969,7 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 			 flag = false;
 			 flag1 = false;
 			 if (l == Blocks.golden_rail) {
-				 flag = (worldObj.getBlockMetadata(i, j, k) & 8) != 0;
+				 flag = ((BlockRailBase)worldObj.getBlock(i, j, k)).getBasicRailMetadata(worldObj, this,i,j,k) != 0;
 				 flag1 = !flag;
 				 if (i1 == 8) {i1 = 0;}
 				 else if (i1 == 9) {i1 = 1;}
@@ -1978,7 +1976,7 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 					}
 					else {
 
-						if (!(par1Entity instanceof EntityItem) && !(par1Entity instanceof EntityPlayer && this instanceof Locomotive) && !(par1Entity instanceof EntityCreature) && !(par1Entity instanceof EntityBogie)) {
+						if (!(par1Entity instanceof EntityItem) && !(par1Entity instanceof EntityPlayer && this instanceof Locomotive) && !(par1Entity instanceof EntityLiving) && !(par1Entity instanceof EntityBogie)) {
 							this.addVelocity(-d0 * 2, 0.0D, -d1 * 2);
 						}
 						else if ((par1Entity instanceof EntityBogie)) {
@@ -2402,12 +2400,12 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 
 	@Override
 	protected void  func_145775_I() {
-		int var1 = MathHelper.floor_double(this.boundingBoxSmall.minX + 0.001D);
-		int var2 = MathHelper.floor_double(this.boundingBoxSmall.minY + 0.001D);
-		int var3 = MathHelper.floor_double(this.boundingBoxSmall.minZ + 0.001D);
-		int var4 = MathHelper.floor_double(this.boundingBoxSmall.maxX - 0.001D);
-		int var5 = MathHelper.floor_double(this.boundingBoxSmall.maxY - 0.001D);
-		int var6 = MathHelper.floor_double(this.boundingBoxSmall.maxZ - 0.001D);
+		int var1 = MathHelper.floor_double(this.getBoundingBox().minX + 0.001D);
+		int var2 = MathHelper.floor_double(this.getBoundingBox().minY + 0.001D);
+		int var3 = MathHelper.floor_double(this.getBoundingBox().minZ + 0.001D);
+		int var4 = MathHelper.floor_double(this.getBoundingBox().maxX - 0.001D);
+		int var5 = MathHelper.floor_double(this.getBoundingBox().maxY - 0.001D);
+		int var6 = MathHelper.floor_double(this.getBoundingBox().maxZ - 0.001D);
 
 		if (this.worldObj.checkChunksExist(var1, var2, var3, var4, var5, var6)) {
 			for (int var7 = var1; var7 <= var4; ++var7) {
@@ -2426,7 +2424,7 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 
 	private void setBoundingBoxSmall(double par1, double par3, double par5, float width, float height) {
 		float var7 = width * 0.5F;
-		this.boundingBoxSmall.setBounds(par1 - var7, par3 - this.yOffset + this.ySize, par5 - var7, par1 + var7, par3 - this.yOffset + this.ySize + height, par5 + var7);
+		this.getBoundingBox().setBounds(par1 - var7, par3 - this.yOffset + this.ySize, par5 - var7, par1 + var7, par3 - this.yOffset + this.ySize + height, par5 + var7);
 	}
 
 	public float getYaw() {
@@ -2447,7 +2445,7 @@ public class EntityRollingStock extends AbstractTrains implements ILinkableCart 
 		List<ItemStack> items = new ArrayList<ItemStack>();
 		for (EnumTrains trains : EnumTrains.values()) {
 			if (trains.getEntityClass().equals(this.getClass())) {
-				items.add(new ItemStack(trains.getItem()));
+				items.add(ItemRollingStock.setPersistentData(new ItemStack(trains.getItem()), this,this.getUniqueTrainID(),trainCreator, trainOwner, getColor()));
 				return items;
 			}
 		}

--- a/src/main/java/train/common/blocks/BlockSwitchStand.java
+++ b/src/main/java/train/common/blocks/BlockSwitchStand.java
@@ -3,6 +3,7 @@ package train.common.blocks;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockLever;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -23,11 +24,11 @@ import train.common.tile.TileSwitchStand;
 import java.util.List;
 import java.util.Random;
 
-public class BlockSwitchStand extends Block {
+public class BlockSwitchStand extends BlockLever {
 	private IIcon texture;
 
 	public BlockSwitchStand() {
-		super(Material.rock);
+		super();
 		setCreativeTab(Traincraft.tcTab);
 		this.setTickRandomly(true);
 		//this.setBlockBounds(0.5F , 0.0F, 0.5F , 0.5F ,  2.0F, 0.5F);
@@ -81,113 +82,6 @@ public class BlockSwitchStand extends Block {
 			int dir = MathHelper.floor_double((double) ((entityliving.rotationYaw * 4F) / 360F) + 0.5D) & 3;
 			te.setFacing(ForgeDirection.getOrientation(dir == 0 ? 2 : dir == 1 ? 5 : dir == 2 ? 3 : 4));
 			world.markBlockForUpdate(i, j, k);
-		}
-	}
-	public boolean onBlockActivated(World p_149727_1_, int p_149727_2_, int p_149727_3_, int p_149727_4_, EntityPlayer p_149727_5_, int p_149727_6_, float p_149727_7_, float p_149727_8_, float p_149727_9_)
-	{
-		if (p_149727_1_.isRemote)
-		{
-			return true;
-		}
-		else
-		{
-			int i1 = p_149727_1_.getBlockMetadata(p_149727_2_, p_149727_3_, p_149727_4_);
-			int j1 = i1 & 7;
-			int k1 = 8 - (i1 & 8);
-			p_149727_1_.setBlockMetadataWithNotify(p_149727_2_, p_149727_3_, p_149727_4_, j1 + k1, 3);
-			p_149727_1_.playSoundEffect((double)p_149727_2_ + 0.5D, (double)p_149727_3_ + 0.5D, (double)p_149727_4_ + 0.5D, "random.click", 0.3F, k1 > 0 ? 0.6F : 0.5F);
-			p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_, this);
-
-			if (j1 == 1)
-			{
-				p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ - 1, p_149727_3_, p_149727_4_, this);
-			}
-			else if (j1 == 2)
-			{
-				p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_ + 1, p_149727_3_, p_149727_4_, this);
-			}
-			else if (j1 == 3)
-			{
-				p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ - 1, this);
-			}
-			else if (j1 == 4)
-			{
-				p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_, p_149727_4_ + 1, this);
-			}
-			else if (j1 != 5 && j1 != 6)
-			{
-				if (j1 == 0 || j1 == 7)
-				{
-					p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ + 1, p_149727_4_, this);
-				}
-			}
-			else
-			{
-				p_149727_1_.notifyBlocksOfNeighborChange(p_149727_2_, p_149727_3_ - 1, p_149727_4_, this);
-			}
-
-			return true;
-		}
-	}
-
-	public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
-	{
-		if ((p_149749_6_ & 8) > 0)
-		{
-			p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_, this);
-			int i1 = p_149749_6_ & 7;
-
-			if (i1 == 1)
-			{
-				p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ - 1, p_149749_3_, p_149749_4_, this);
-			}
-			else if (i1 == 2)
-			{
-				p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_ + 1, p_149749_3_, p_149749_4_, this);
-			}
-			else if (i1 == 3)
-			{
-				p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ - 1, this);
-			}
-			else if (i1 == 4)
-			{
-				p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_, p_149749_4_ + 1, this);
-			}
-			else if (i1 != 5 && i1 != 6)
-			{
-				if (i1 == 0 || i1 == 7)
-				{
-					p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ + 1, p_149749_4_, this);
-				}
-			}
-			else
-			{
-				p_149749_1_.notifyBlocksOfNeighborChange(p_149749_2_, p_149749_3_ - 1, p_149749_4_, this);
-			}
-		}
-
-		super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
-	}
-
-
-
-	public int isProvidingWeakPower(IBlockAccess p_149709_1_, int p_149709_2_, int p_149709_3_, int p_149709_4_, int p_149709_5_)
-	{
-		return (p_149709_1_.getBlockMetadata(p_149709_2_, p_149709_3_, p_149709_4_) & 8) > 0 ? 15 : 0;
-	}
-
-	public int isProvidingStrongPower(IBlockAccess p_149748_1_, int p_149748_2_, int p_149748_3_, int p_149748_4_, int p_149748_5_)
-	{
-		int i1 = p_149748_1_.getBlockMetadata(p_149748_2_, p_149748_3_, p_149748_4_);
-
-		if ((i1 & 8) == 0)
-		{
-			return 0;
-		}
-		else
-		{
-			int j1 = i1 & 7;
-			return j1 == 0 && p_149748_5_ == 0 ? 15 : (j1 == 7 && p_149748_5_ == 0 ? 15 : (j1 == 6 && p_149748_5_ == 1 ? 15 : (j1 == 5 && p_149748_5_ == 1 ? 15 : (j1 == 4 && p_149748_5_ == 2 ? 15 : (j1 == 3 && p_149748_5_ == 3 ? 15 : (j1 == 2 && p_149748_5_ == 4 ? 15 : (j1 == 1 && p_149748_5_ == 5 ? 15 : 0)))))));
 		}
 	}
 

--- a/src/main/java/train/common/core/handlers/CollisionHandler.java
+++ b/src/main/java/train/common/core/handlers/CollisionHandler.java
@@ -43,8 +43,8 @@ public class CollisionHandler {
 		 */
 		listRide = worldObj.getEntitiesWithinAABBExcludingEntity(entityOne, boundingBox.expand(-0.5, -0.5, -0.5));
 		if (listRide != null && listRide.size() > 0) {
-			for (int j1 = 0; j1 < listRide.size(); j1++) {
-				entity = (Entity) listRide.get(j1);
+			for (Object aListRide : listRide) {
+				entity = (Entity) aListRide;
 				if (!(entity instanceof EntityLasersLines) && !entity.noClip) {
 					if (entity != entity.riddenByEntity && !(unAutorizedMob(entity, entityOne)) && (entity instanceof EntityLiving)) {
 						applyRideEntity(entity, entityOne);
@@ -64,8 +64,8 @@ public class CollisionHandler {
 		listRide = worldObj.getEntitiesWithinAABBExcludingEntity(entityOne, box);
 		if (listRide != null && listRide.size() > 0) {
 
-			for (int j1 = 0; j1 < listRide.size(); j1++) {
-				entity = (Entity) listRide.get(j1);
+			for (Object aListRide : listRide) {
+				entity = (Entity) aListRide;
 
 				if (!(entity instanceof EntityLasersLines) && !entity.noClip) {
 
@@ -90,8 +90,8 @@ public class CollisionHandler {
 		listRide = worldObj.getEntitiesWithinAABBExcludingEntity(entityOne, box);
 		if (listRide != null && listRide.size() > 0) {
 
-			for (int j1 = 0; j1 < listRide.size(); j1++) {
-				entity = (Entity) listRide.get(j1);
+			for (Object aListRide : listRide) {
+				entity = (Entity) aListRide;
 				if (!(entity instanceof EntityLasersLines) && !entity.noClip && !(entity instanceof EntityLiving) && !(entityOne instanceof EntityLiving)) {
 
 					if (entity != entity.riddenByEntity && entity.canBePushed() && (entityOne instanceof AbstractTrains) && (entity instanceof AbstractTrains) && !((AbstractTrains) entityOne).isAttached) {
@@ -129,8 +129,8 @@ public class CollisionHandler {
 	 */
 	public void applyEntityCollisionVanilla(Entity par1Entity, EntityMinecart entityOne) {
 		MinecraftForge.EVENT_BUS.post(new MinecartCollisionEvent(entityOne, par1Entity));
-		if (entityOne.getCollisionHandler() != null) {
-			entityOne.getCollisionHandler().onEntityCollision(entityOne, par1Entity);
+		if (EntityMinecart.getCollisionHandler() != null) {
+			EntityMinecart.getCollisionHandler().onEntityCollision(entityOne, par1Entity);
 			return;
 		}
 		if (!this.worldObj.isRemote) {
@@ -389,13 +389,17 @@ public class CollisionHandler {
 						if ((f1 * 3.6) < 35) {//if speed is smaller than 35km/h then don't do any damage but push entities
 							if (f7 == 0) {
 
-								movingobjectposition.entityHit.addVelocity(d * 0.666666667, 0.0D, d1 * 0.666666667);
+								//movingobjectposition.entityHit.addVelocity(d * 0.666666667, 0.0D, d1 * 0.666666667);
+								movingobjectposition.entityHit.motionX+=d * 0.666666667;
+								movingobjectposition.entityHit.motionZ+=d1 * 0.666666667;
 
 								entity.velocityChanged = true;
 								return;
 							}
 							//System.out.println("bla");
-							movingobjectposition.entityHit.addVelocity(((entityOne.motionX * 1 * 0.060000002384185791D)) / f7, 0.00000000000000001D, (((entityOne.motionZ * 1 * 0.060000002384185791D)) / f7));
+							//movingobjectposition.entityHit.addVelocity(((entityOne.motionX * 1 * 0.060000002384185791D)) / f7, 0.00000000000000001D, (((entityOne.motionZ * 1 * 0.060000002384185791D)) / f7));
+							movingobjectposition.entityHit.motionX+=((entityOne.motionX * 1 * 0.060000002384185791D)) / f7;
+							movingobjectposition.entityHit.motionZ+=(((entityOne.motionZ * 1 * 0.060000002384185791D)) / f7);
 							entity.velocityChanged = true;
 							return;
 						}
@@ -410,7 +414,9 @@ public class CollisionHandler {
 
 							entity.attackEntityFrom(TrainsDamageSource.ranOver, j1);//DamageSource.causeMobDamage((EntityLiving) entity);
 							if (f7 > 0.0F) {
-								movingobjectposition.entityHit.addVelocity((entityOne.motionX * 2 * 0.60000002384185791D) / f7, 0.10000000000000001D, (entityOne.motionZ * 2 * 0.60000002384185791D) / f7);
+								//movingobjectposition.entityHit.addVelocity((entityOne.motionX * 2 * 0.60000002384185791D) / f7, 0.10000000000000001D, (entityOne.motionZ * 2 * 0.60000002384185791D) / f7);
+								movingobjectposition.entityHit.motionX+=(entityOne.motionX * 2 * 0.60000002384185791D) / f7;
+								movingobjectposition.entityHit.motionZ+=(entityOne.motionZ * 2 * 0.60000002384185791D) / f7;
 								entity.velocityChanged = true;
 							}
 

--- a/src/main/java/train/common/items/ItemRollingStock.java
+++ b/src/main/java/train/common/items/ItemRollingStock.java
@@ -1,6 +1,7 @@
 package train.common.items;
 
 import com.mojang.authlib.GameProfile;
+import com.sun.istack.internal.Nullable;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import mods.railcraft.api.carts.IMinecart;
@@ -401,6 +402,46 @@ public class ItemRollingStock extends ItemMinecart implements IMinecart, IMineca
 		}
 		return rollingStock;
 	}
+	public static ItemStack setPersistentData(@Nullable ItemStack oldStack, @Nullable AbstractTrains train, @Nullable Integer trainID, @Nullable String player, @Nullable String creator, int color) {
+
+		ItemStack stack = oldStack;
+
+		if (train != null){
+			for (EnumTrains trains : EnumTrains.values()) {
+				if (trains.getEntityClass().equals(train.getClass())) {
+					stack = (new ItemStack(trains.getItem()));
+					break;
+				}
+			}
+		}
+		if(stack!=null) {
+			NBTTagCompound tag = stack.getTagCompound();
+			if(tag==null){
+				tag=new NBTTagCompound();
+			}
+			if(train!=null) {
+				tag.setString("puuid", train.getPersistentUUID());
+				tag.setString("trainCreator", creator==null?train.getEntityData().getString("theCreator"):creator);
+				if(player!=null && player.length()>1) {
+					tag.setString("theOwner", player);
+				}
+				if(color >0) {
+					tag.setInteger("trainColor",color);
+				}
+			} else {
+				tag.setString("trainCreator", creator!=null && creator.length()>1?creator:"Creative");
+			}
+			tag.setInteger("uniqueID", trainID==null?AbstractTrains.uniqueIDs++:trainID);
+
+
+			stack.setTagCompound(tag);
+		} else {
+			return null;//THIS SHOULD NEVER HAPPEN, but compensate anyway because java is stupid and forge is unreliable.
+		}
+		return stack;
+
+	}
+
 
 	@Override
 	public boolean canBePlacedByNonPlayer(ItemStack cart) {

--- a/src/main/java/train/common/items/ItemTCRail.java
+++ b/src/main/java/train/common/items/ItemTCRail.java
@@ -104,6 +104,7 @@ public class ItemTCRail extends ItemPart {
 	}
 
 	public static boolean isTCTurnTrack(TileTCRail tile) {
+		if(tile==null || tile.getType()==null){return false;}
 		return (tile.getType().equals(TrackTypes.MEDIUM_LEFT_SWITCH.getLabel()) && tile.getSwitchState())
 				|| (tile.getType().equals(TrackTypes.MEDIUM_RIGHT_SWITCH.getLabel()) && tile.getSwitchState())
 				|| (tile.getType().equals(TrackTypes.LARGE_LEFT_SWITCH.getLabel()) && tile.getSwitchState())
@@ -121,6 +122,7 @@ public class ItemTCRail extends ItemPart {
 	}
 
 	public static boolean isTCStraightTrack(TileTCRail tile) {
+		if(tile==null || tile.getType()==null){return false;}
 		return (tile.getType().equals(TrackTypes.MEDIUM_LEFT_SWITCH.getLabel()) && !tile.getSwitchState())
 				|| (tile.getType().equals(TrackTypes.MEDIUM_RIGHT_SWITCH.getLabel()) && !tile.getSwitchState())
 				|| (tile.getType().equals(TrackTypes.LARGE_LEFT_SWITCH.getLabel()) && !tile.getSwitchState())
@@ -139,14 +141,17 @@ public class ItemTCRail extends ItemPart {
 	}
 
 	public static boolean isTCTwoWaysCrossingTrack(TileTCRail tile) {
+		if(tile==null || tile.getType()==null){return false;}
 		return tile.getType().equals(TrackTypes.TWO_WAYS_CROSSING.getLabel());
 	}
 
 	public static boolean isTCSwitch(TileTCRail tile) {
+		if(tile==null || tile.getType()==null){return false;}
 		return (tile.getType().equals(TrackTypes.MEDIUM_LEFT_SWITCH.getLabel())) || (tile.getType().equals(TrackTypes.MEDIUM_RIGHT_SWITCH.getLabel())) || (tile.getType().equals(TrackTypes.LARGE_LEFT_SWITCH.getLabel())) || (tile.getType().equals(TrackTypes.LARGE_RIGHT_SWITCH.getLabel())) || (tile.getType().equals(TrackTypes.MEDIUM_RIGHT_PARALLEL_SWITCH.getLabel())) || (tile.getType().equals(TrackTypes.MEDIUM_LEFT_PARALLEL_SWITCH.getLabel()));
 	}
 
 	public static boolean isTCSlopeTrack(TileTCRail tile) {
+		if(tile==null || tile.getType()==null){return false;}
 		return tile.getType().equals(TrackTypes.SLOPE_WOOD.getLabel())
 				|| tile.getType().equals(TrackTypes.SLOPE_GRAVEL.getLabel())
 				|| tile.getType().equals(TrackTypes.SLOPE_BALLAST.getLabel())


### PR DESCRIPTION
- All switch stands are now an instance of BlockLever, so it should work with permission and greif prevention plugins.
- Train collisions with players should no longer kick the player with the error "flying is not allowed"
- Increased the height of the bounding box slightly to fix interaction with loaders and unloaders from above the transport, this also removed an unused secondary bounding box instance.
- Fixed a collision bug with the flamethrower from mekanism, due to the bogie technically being flammable.
- Small improvements to collision logic.
- Fixed a bug with the item data that prevented it. from getting information like the owner, creator, and color.
- Admin book now has a clone and delete entry option.
- Fixed some crashes related to data issues in the tile entities.