### PR TITLE
Small Overlay Change & Lock Menu Crash Fix

### DIFF
--- a/src/main/java/train/client/gui/GuiDynamicOverlay.java
+++ b/src/main/java/train/client/gui/GuiDynamicOverlay.java
@@ -15,14 +15,12 @@ import train.common.core.network.PacketTextureOverlayConfig;
 import train.common.library.GuiIDs;
 import train.common.library.Info;
 import train.common.overlaytexture.OTSpecificationDynamic;
-import train.common.overlaytexture.OverlayTextureManager;
 
 import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 
 /**
@@ -103,10 +101,6 @@ public class GuiDynamicOverlay extends GuiScreen {
      * Mouse coordinates stored to find the color selected on the color grid.
      */
     private int mouseY;
-    /**
-     * <p>Number of the overlay currently being displayed and set with respect to all available overlays for this model.</p>
-     */
-    private int correctedDynamicOverlayNumber;
     private GuiTextFieldDynamicOverlay overlayTextBox;
     private GuiTextFieldDynamicOverlay colorCodeTextBox;
     private int ticksExisted = 0;
@@ -358,6 +352,7 @@ public class GuiDynamicOverlay extends GuiScreen {
                 throw new IOException();
             }
         } catch (UnsupportedFlavorException | IOException ignored) {
+            Traincraft.tcLog.warn("Unsupported hex color import action attempted in dynamic overlay menu.");
             colorCodeTextBox.setText("");
         }
     }

--- a/src/main/java/train/client/gui/GuiLockMenuAbstract.java
+++ b/src/main/java/train/client/gui/GuiLockMenuAbstract.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 import org.lwjgl.input.Mouse;
+import train.common.Traincraft;
 import train.common.core.handlers.ConfigHandler;
 import train.common.entity.TrustedPlayer;
 import train.common.library.Info;
@@ -175,6 +176,10 @@ public abstract class GuiLockMenuAbstract extends GuiScreen {
             drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("lockmenu.Save and Close.name")), mouseX, mouseY, fontRendererObj);
         if (closeAndSavetoAll.getTexture() == GuiButtonLockMenu.Texture.ACTIVE)
             drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("lockmenu.Save To All Cars in Consist.name")), mouseX, mouseY, fontRendererObj);
+        if (copyButton.getTexture() == GuiButtonLockMenu.Texture.ACTIVE)
+            drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("lockmenu.Copy.name")), mouseX, mouseY, fontRendererObj);
+        if (pasteButton.getTexture() == GuiButtonLockMenu.Texture.ACTIVE)
+            drawHoveringText(Collections.singletonList(StatCollector.translateToLocal("lockmenu.Paste.name")), mouseX, mouseY, fontRendererObj);
     }
 
     @Override
@@ -228,7 +233,7 @@ public abstract class GuiLockMenuAbstract extends GuiScreen {
                             updateButtons();
                         }
                     } catch (UnsupportedFlavorException | IOException e) {
-                        throw new RuntimeException(e);
+                        Traincraft.tcLog.warn("Unsupported paste action attempted in lock menu.");
                     }
                 default:
                     if (clickedButton.id >= NUMBER_OF_STATIC_BUTTONS && clickedButton.id < MAX_TRUSTEES_ON_PAGE + NUMBER_OF_STATIC_BUTTONS) { // Line Select Delete Buttons
@@ -336,5 +341,10 @@ public abstract class GuiLockMenuAbstract extends GuiScreen {
         return textFieldList;
     }
     public int getCurrentPage() { return currentPage; }
+
+    @Override
+    public boolean doesGuiPauseGame() {
+        return false;
+    }
 
 }

--- a/src/main/java/train/common/overlaytexture/OTSpecificationDynamic.java
+++ b/src/main/java/train/common/overlaytexture/OTSpecificationDynamic.java
@@ -16,8 +16,7 @@ import java.util.Map;
  */
 public class OTSpecificationDynamic extends OTSpecification
 {
-    final float fontSize;
-    final float fontSpacing;
+    private final Map<TextAttribute, Object> fontAttributes;
     final int maxWidth;
     final int maxHeight;
     final private OverlayFontRegistry.OverlayFont font;
@@ -41,18 +40,16 @@ public class OTSpecificationDynamic extends OTSpecification
      * @param maxHeight Maximum height of overlay.
      * @param characterLimit Optional character limit. For default, set to null.
      * @param font Font registered in EnumOverlayFonts.
-     * @param fontSize Font size.
-     * @param fontSpacing Font spacing. Default is 0.0f.
+     * @param fontAttributes Map of font attributes to customize font size, spacing, kerning, etc.
      * @param alignmentMode Alignment mode dictating how the text will be drawn in the given overlay.
      * @param drawingPointsList List of points on the texture map for a given model on which to draw the overlay.
      */
-    public OTSpecificationDynamic(String overlayName, int maxWidth, int maxHeight, Integer characterLimit, IOverlayFont font, float fontSize, float fontSpacing, AlignmentMode alignmentMode, Point[] drawingPointsList) {
+    public OTSpecificationDynamic(String overlayName, int maxWidth, int maxHeight, Integer characterLimit, IOverlayFont font, Map<TextAttribute, Object> fontAttributes, AlignmentMode alignmentMode, Point[] drawingPointsList) {
         super(drawingPointsList, overlayName);
         this.maxWidth = maxWidth;
         this.maxHeight = maxHeight;
         this.characterLimit = characterLimit;
-        this.fontSize = fontSize;
-        this.fontSpacing = fontSpacing;
+        this.fontAttributes = fontAttributes;
         this.alignmentMode = alignmentMode;
         this.font = OverlayFontRegistry.getFont(font);
     }
@@ -73,8 +70,8 @@ public class OTSpecificationDynamic extends OTSpecification
         this.maxWidth = maxWidth;
         this.maxHeight = maxHeight;
         this.characterLimit = characterLimit;
-        this.fontSize = fontSize;
-        this.fontSpacing = 0.0f;
+        this.fontAttributes = new HashMap<>(1);
+        fontAttributes.put(TextAttribute.SIZE, fontSize);
         this.alignmentMode = alignmentMode;
         this.font = OverlayFontRegistry.getFont(font);
     }
@@ -83,9 +80,6 @@ public class OTSpecificationDynamic extends OTSpecification
     @Override
     @SideOnly(Side.CLIENT)
     public void renderOverlay() {
-        Map<TextAttribute, Object> fontAttributes = new HashMap<>(2);
-        fontAttributes.put(TextAttribute.SIZE, fontSize);
-        fontAttributes.put(TextAttribute.TRACKING, fontSpacing);
         Font renderFont = font.getFont().deriveFont(fontAttributes);
         overlayImage = new BufferedImage(maxWidth, maxHeight, BufferedImage.TYPE_INT_ARGB);
         Graphics graphics = overlayImage.getGraphics();

--- a/src/main/resources/assets/tc/lang/en_US.lang
+++ b/src/main/resources/assets/tc/lang/en_US.lang
@@ -136,6 +136,8 @@ lockmenu.Lock.name=Lock
 lockmenu.Title_Trusted_Players.name=Trusted Players
 lockmenu.Save and Close.name=Save and Close
 lockmenu.Save To All Cars in Consist.name=Save To All Cars in Consist
+lockmenu.Copy.name=Copy Configuration
+lockmenu.Paste.name=Paste Configuration
 
 <!-- ## GUI ## -->
 menu.item.slots=Slots

--- a/src/main/resources/assets/tc/lang/es_ES.lang
+++ b/src/main/resources/assets/tc/lang/es_ES.lang
@@ -370,6 +370,9 @@ lockmenu.Lock.name=Cerrar
 lockmenu.Title_Trusted_Players.name=Jugadores de Confianza
 lockmenu.Save and Close.name=Entregar y Salir
 lockmenu.Save To All Cars in Consist.name=Entregar a Todos Los Coches en el Tren
+lockmenu.Copy.name=Copiar Configuración
+lockmenu.Paste.name=Pegar Configuración
+
 <!-- ## ENTITY ## --> 
 entity.tc.Entity Front Bogie.name=Bogie 
 entity.tc.zeppelin big.name=Zepelín


### PR DESCRIPTION
- Dynamic overlays can now accept a TextAttribute map, per standard java.awt.Font convention, to control all aspects of font rendering including size, spacing, kerning, style, and more.
- Fixed lock menu crashing when pasting unsupported values.