### PR TITLE
Remove Green from Public Domain

### DIFF
--- a/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/diesel/DieselF3A.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/diesel/DieselF3A.java
@@ -23,7 +23,7 @@ public class DieselF3A extends DieselTrain {
         InsertTexture(1, "FMSR", LockoutGroup.FMSR);
         InsertTexture(2, "FNCC (Ex FMSR)", LockoutGroup.FNCC);
         InsertTexture(3, "DES", LockoutGroup.DES);
-        InsertTexture(4, "CDC&S");
+        InsertTexture(4, "CDC&S", LockoutGroup.CDCS);
         InsertTexture(5, "OC&G 25A, 26B", LockoutGroup.CUBED);
         InsertTexture(6, "BAR 49");
         InsertTexture(7, "DRGW (Black with yellow stripes)");

--- a/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/diesel/DieselGP7.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/diesel/DieselGP7.java
@@ -68,7 +68,7 @@ public class DieselGP7 extends DieselTrain {
         InsertTexture(46, "Great Lakes & Northern Territories (Ex FNCC)");
         InsertTexture(47, "Monongahela");
         InsertTexture(48, "WCP (stupid bozo chop)");
-        InsertTexture(49, "CDCS");
+        InsertTexture(49, "CDCS", LockoutGroup.CDCS);
         InsertTexture(50, "JRN");
         InsertTexture(51, "GCCR");
         InsertTexture(52, "WM (As Delivered)");

--- a/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamAlco0_6_0T.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamAlco0_6_0T.java
@@ -20,7 +20,7 @@ public class SteamAlco0_6_0T extends SteamTrain {
 		super(world, EnumTrains.Alco0_6_0T.getTankCapacity(), LiquidManager.WATER_FILTER);
 		
 		InsertTexture(0, "Generic");
-		InsertTexture(1, "CDCS");
+		InsertTexture(1, "CDCS", LockoutGroup.CDCS);
 		InsertTexture(2, "SPR", LockoutGroup.SPR);
 	}
 

--- a/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamAlco460.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamAlco460.java
@@ -21,7 +21,7 @@ public class SteamAlco460 extends SteamTrain {
 		super(world, EnumTrains.Alco460.getTankCapacity(), LiquidManager.WATER_FILTER);
 		
 		InsertTexture(0, "Blank");
-		InsertTexture(1, "CDC&S");
+		InsertTexture(1, "CDC&S", LockoutGroup.CDCS);
 		InsertTexture(2, "RI");
 		InsertTexture(3, "%Lemo");
 		InsertTexture(4, "GCM 67", LockoutGroup.GCM);

--- a/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamBrank.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamBrank.java
@@ -5,6 +5,7 @@ import net.minecraft.world.World;
 import train.common.api.LiquidManager;
 import train.common.api.SteamTrain;
 import train.common.core.util.TraincraftUtil;
+import train.common.enums.LockoutGroup;
 import train.common.library.EnumSounds;
 import train.common.library.EnumTrains;
 import train.common.library.sounds.SoundRecord;
@@ -18,7 +19,7 @@ public class SteamBrank extends SteamTrain {
 	public SteamBrank(World world) {
 		super(world, EnumTrains.Brank.getTankCapacity(), LiquidManager.WATER_FILTER);
 		
-		InsertTexture(0, "pregnant man railroad company");
+		InsertTexture(0, "pregnant man railroad company", LockoutGroup.CDCS);
 	}
 
 	@Override

--- a/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamClimaxB.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamClimaxB.java
@@ -22,7 +22,7 @@ public class SteamClimaxB extends SteamTrain {
 		InsertTexture(0, "Hillcrest Lumber Co #9");
 		InsertTexture(1, "Washaska Resources #6", LockoutGroup.BIDA);
 		InsertTexture(2, "Washaska Resources #7", LockoutGroup.BIDA);
-		InsertTexture(3, "Clarks Milling & Lumber Co");
+		InsertTexture(3, "Clarks Milling & Lumber Co", LockoutGroup.CDCS);
 	}
 
 	@Override

--- a/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamLima2_8_0.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamLima2_8_0.java
@@ -5,6 +5,7 @@ import net.minecraft.world.World;
 import train.common.api.LiquidManager;
 import train.common.api.SteamTrain;
 import train.common.core.util.TraincraftUtil;
+import train.common.enums.LockoutGroup;
 import train.common.library.EnumSounds;
 import train.common.library.EnumTrains;
 import train.common.library.sounds.SoundRecord;
@@ -19,9 +20,9 @@ public class SteamLima2_8_0 extends SteamTrain {
 		super(world, EnumTrains.Lima2_8_0.getTankCapacity(), LiquidManager.WATER_FILTER);
 		
 		InsertTexture(0, "Generic");
-		InsertTexture(1, "CDCS 20");
-		InsertTexture(2, "CDCS 21");
-		InsertTexture(3, "CDCS 22");
+		InsertTexture(1, "CDCS 20", LockoutGroup.CDCS);
+		InsertTexture(2, "CDCS 21", LockoutGroup.CDCS);
+		InsertTexture(3, "CDCS 22", LockoutGroup.CDCS);
 		InsertTexture(4, "A&WRR");
 		InsertTexture(5, "CRIP");
 	}

--- a/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamP01a.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/locomotives/steam/SteamP01a.java
@@ -22,7 +22,7 @@ public class SteamP01a extends SteamTrain {
 		
 		InsertTexture(0, "WRX 10", LockoutGroup.BIDA);
 		InsertTexture(1, "WRX 12", LockoutGroup.BIDA);
-		InsertTexture(2, "CDC&S 7");
+		InsertTexture(2, "CDC&S 7", LockoutGroup.CDCS);
 	}
 
 	@Override

--- a/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/rollingstock/workcart/CDCScaboose.java
+++ b/src/main/java/com/jcirmodelsquad/tcjcir/vehicles/rollingstock/workcart/CDCScaboose.java
@@ -3,13 +3,14 @@ package com.jcirmodelsquad.tcjcir.vehicles.rollingstock.workcart;
 import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.world.World;
 import train.common.api.AbstractWorkCart;
+import train.common.enums.LockoutGroup;
 
 public class CDCScaboose extends AbstractWorkCart
 {
     public CDCScaboose(World world) {
         super(world);
-        InsertTexture(0, "CDCS");
-        InsertTexture(1, "CDCS (Modernized)");
+        InsertTexture(0, "CDCS", LockoutGroup.CDCS);
+        InsertTexture(1, "CDCS (Modernized)", LockoutGroup.CDCS);
         InsertTexture(2, "NPS");
         InsertTexture(3, "MOW");
     }
@@ -30,5 +31,15 @@ public class CDCScaboose extends AbstractWorkCart
     public float getOptimalDistance(EntityMinecart cart)
     {
         return 2.0375F;
+    }
+
+    @Override
+    public boolean isFictional() {
+        return true;
+    }
+
+    @Override
+    public String getInventoryName() {
+        return "CDCS Shopbuilt Caboose";
     }
 }

--- a/src/main/java/train/common/enums/LockoutGroup.java
+++ b/src/main/java/train/common/enums/LockoutGroup.java
@@ -49,7 +49,10 @@ public enum LockoutGroup implements ILockoutGroup
     DLMR("8ce3fa8e-9f27-48c5-b97e-de12ad735296"),//deadwood & la mesa
     AGW("8ce3fa8e-9f27-48c5-b97e-de12ad735296"),// adelante great western or whatsitsface spelled lol
 
-    JCTransit()
+    JCTransit(),
+
+    //Cheesewheel
+    CDCS("43efda8c-f591-4f7e-bc54-c4978484e69f"), //Clarksville, Deer Creek & Southern
     ;
 
     /**


### PR DESCRIPTION
-Add CDCS Lockout tab
-Add all CDCS Skins to CDCS lockout tab
-Affects skins on F3A, GP7, Alco 0-6-0T, Alco 4-6-0, Lima 2-8-0, The Brank, Climax B, P01a, and CDCS Caboose