### PR TITLE
New Audio System, New BOB Model Settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ buildscript {
 
 apply plugin: 'forge'
 apply plugin: 'idea'
+
 sourceCompatibility = targetCompatibility = "1.8"
 compileJava { sourceCompatibility = targetCompatibility = "1.8" }
 
@@ -37,6 +38,11 @@ version = "3.1.9.2"
 group= "src.train" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Fox-Traincraft"
 
+configurations {
+    shade
+    compile.extendsFrom shade
+}
+
 minecraft {
     version = "1.7.10-10.13.4.1614-1.7.10"
     runDir = "run"
@@ -49,10 +55,14 @@ repositories {
         name "ChickenBones"
         url "http://chickenbones.net/maven/"
     }
-	   maven { 
+   maven {
         url = "http://maven.cil.li/"
     }
+    maven {
+        url "https://jitpack.io"
+    }
 }
+
 
 dependencies {
     repositories {
@@ -76,6 +86,15 @@ dependencies {
 	compile "codechicken:CodeChickenCore:1.7.10-1.0.7.47:dev"
 	compile "codechicken:NotEnoughItems:1.7.10-1.0.5.120:dev"
     compile "codechicken:ForgeMultipart:1.7.10-1.2.0.345:dev"
+    //libraries for replacing the jukebox player. The top one is the one we actually use. The rest are for file types and various other things within java-stream-player
+    shade 'com.github.goxr3plus:java-stream-player:10.0.2'
+    shade 'com.googlecode.soundlibs:mp3spi:1.9.5.4'
+    shade 'org.jflac:jflac-codec:1.5.2'
+    shade 'com.googlecode.soundlibs:vorbisspi:1.0.3.3'
+    shade 'com.googlecode.soundlibs:tritonus-share:0.3.7.4'
+    shade 'com.googlecode.soundlibs:jorbis:0.0.17'
+    shade 'com.github.goxr3plus:jaudiotagger:2.2.7'
+    shade 'commons-io:commons-io:2.7'
     compile fileTree(dir: 'libs', include: ['*.jar'])
     // real examples
     //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
@@ -98,6 +117,42 @@ repositories {
 
 dependencies {
     compile "mcp.mobius.waila:Waila:1.5.10_1.7.10:dev"
+}
+
+jar {
+    def serviceEntries = [:].withDefault { [] }
+    def tmpDir = file("$buildDir/mergedServices")
+
+    configurations.shade.each { dep ->
+        from(project.zipTree(dep)) {
+            exclude 'META-INF/*.SF'
+            exclude 'META-INF/*.DSA'
+            exclude 'META-INF/*.RSA'
+            exclude 'META-INF/MANIFEST.MF'
+            exclude 'META-INF/services/**'
+        }
+
+        def zip = new java.util.zip.ZipFile(dep)
+        zip.entries().each { entry ->
+            if (entry.name.startsWith('META-INF/services/') && !entry.isDirectory()) {
+                def lines = zip.getInputStream(entry).text.trim()
+                serviceEntries[entry.name].addAll(lines.split('\r?\n').findAll { !it.trim().isEmpty() })
+            }
+        }
+        zip.close()
+    }
+
+    doFirst {
+        if (tmpDir.exists()) tmpDir.deleteDir()
+
+        serviceEntries.each { path, lines ->
+            def f = file("$tmpDir/$path")
+            f.parentFile.mkdirs()
+            f.text = lines.unique().join('\n') + '\n'
+        }
+    }
+
+    from(tmpDir)
 }
 
 processResources

--- a/src/main/java/fexcraft/fvtm/BOBRollingStockModel.java
+++ b/src/main/java/fexcraft/fvtm/BOBRollingStockModel.java
@@ -1,5 +1,6 @@
 package fexcraft.fvtm;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
@@ -54,19 +55,20 @@ public class BOBRollingStockModel extends FVTMFormatBase {
     public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5) {
         model.render(entity, f, f1, f2, f3, f4, f5);
         AbstractTrains train = (AbstractTrains) entity;
+        if (((AbstractTrains) entity).getCargoManager() != null) {
+            ((AbstractTrains) entity).getCargoManager().renderCargo((AbstractTrains) entity, f, f1, f2, f3, f4, f5);
+        }
         ModelDetailInformation info = details.get(train.getColor());
         if (info == null) {
             info = details.get(0);
         }
-        if (((AbstractTrains) entity).getCargoManager() != null)
-        {
-            ((AbstractTrains) entity).getCargoManager().renderCargo((AbstractTrains) entity, f, f1, f2, f3, f4, f5);
-        }
-        if (info == null)
-        {
+        if (info == null) {
             return;
         }
         for (int i = 0; i < info.models.size(); i++) {
+            if (shouldSkipRender(entity, info, i)) {
+                continue;
+            }
             GL11.glPushMatrix();
             if (info.textures.size() > i && info.textures.get(i) != null) {
                 Tessellator.bindTexture(info.textures.get(i));
@@ -88,5 +90,35 @@ public class BOBRollingStockModel extends FVTMFormatBase {
             info.models.get(i).render(entity, f, f1, f2, f3, f4, f5);
             GL11.glPopMatrix();
         }
+    }
+
+    public static boolean shouldSkipRender(Entity entity, ModelDetailInformation info, int index) {
+        switch (info.modelRenderMethod.get(info.models.get(index))) {
+            case 1: {
+                //if not the riding entity, or not in first person skip the model.
+                return Minecraft.getMinecraft().thePlayer != entity.riddenByEntity || Minecraft.getMinecraft().gameSettings.thirdPersonView != 0;
+            }
+            case 2: {
+                //if not in first person skip the model.
+                return Minecraft.getMinecraft().gameSettings.thirdPersonView != 0;
+            }
+            case 3: {
+                //if not the riding entity, or not in third person skip the model.
+                return Minecraft.getMinecraft().thePlayer != entity.riddenByEntity || Minecraft.getMinecraft().gameSettings.thirdPersonView == 0;
+            }
+            case 4: {
+                //if not in third person skip the model.
+                return Minecraft.getMinecraft().gameSettings.thirdPersonView == 0;
+            }
+            case 5: {
+                //if not in the car
+                return Minecraft.getMinecraft().thePlayer == entity.riddenByEntity;
+            }
+            case 6: {
+                //in the car
+                return Minecraft.getMinecraft().thePlayer != entity.riddenByEntity;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/fexcraft/fvtm/ModelDetailInformation.java
+++ b/src/main/java/fexcraft/fvtm/ModelDetailInformation.java
@@ -4,17 +4,35 @@ import net.minecraft.util.ResourceLocation;
 import tmt.FVTMFormatBase;
 import tmt.Vec3f;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 
+/**
+ * @author broscolotos
+ */
 public class ModelDetailInformation {
+    /**
+     * the 'modelRenderMethod' HashMap is a map of model -> render filter.
+     * The render filter specifies what conditions the detail model will be rendered:
+     * 0: all the time
+     * 1: first person only, and when in the car
+     * 2: first person only
+     * 3: third person only, and when in the car
+     * 4: third person only
+     * 5: not in the car, regardless of viewpoint
+     * 6: in the car, regardless of viewpoint
+     */
+    public HashMap<FVTMFormatBase, Integer> modelRenderMethod = new HashMap<>();
     public LinkedList<FVTMFormatBase> models = new LinkedList<>();
     public LinkedList<Vec3f> positions = new LinkedList<>();
     public LinkedList<Vec3f> rotations = new LinkedList<>();
     public LinkedList<Vec3f> scales = new LinkedList<>();
     public LinkedList<ResourceLocation> textures = new LinkedList<>();
 
+
     public ModelDetailInformation addModel(FVTMFormatBase model, Vec3f position, Vec3f rotation, Vec3f scale, ResourceLocation texture) {
         models.add(model);
+        modelRenderMethod.put(model, 0);
         positions.add(position);
         rotations.add(rotation);
         scales.add(scale);
@@ -24,6 +42,27 @@ public class ModelDetailInformation {
 
     public ModelDetailInformation addModel(FVTMFormatBase model, Vec3f position, Vec3f rotation, Vec3f scale, String texture) {
         models.add(model);
+        modelRenderMethod.put(model, 0);
+        positions.add(position);
+        rotations.add(rotation);
+        scales.add(scale);
+        textures.add(new ResourceLocation(texture));
+        return this;
+    }
+
+    public ModelDetailInformation addModel(FVTMFormatBase model, int renderFilter, Vec3f position, Vec3f rotation, Vec3f scale, ResourceLocation texture) {
+        models.add(model);
+        modelRenderMethod.put(model, renderFilter);
+        positions.add(position);
+        rotations.add(rotation);
+        scales.add(scale);
+        textures.add(texture);
+        return this;
+    }
+
+    public ModelDetailInformation addModel(FVTMFormatBase model, int renderFilter, Vec3f position, Vec3f rotation, Vec3f scale, String texture) {
+        models.add(model);
+        modelRenderMethod.put(model, renderFilter);
         positions.add(position);
         rotations.add(rotation);
         scales.add(scale);

--- a/src/main/java/train/client/core/handlers/ClientTickHandler.java
+++ b/src/main/java/train/client/core/handlers/ClientTickHandler.java
@@ -11,7 +11,7 @@ import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.item.ItemStack;
 import train.client.core.helpers.CapesHelper;
 import train.common.Traincraft;
-import train.common.core.util.MP3Player;
+import train.common.core.util.ReplacementStreamPlayer;
 import train.common.library.Info;
 
 public class ClientTickHandler {
@@ -36,7 +36,7 @@ public class ClientTickHandler {
 
 	private void tickStart(TickEvent event) {
 		if (mc.theWorld == null) { // fixes streaming after exiting a world
-			for (MP3Player player : Traincraft.proxy.playerList) if (player != null) player.stop();
+			for (ReplacementStreamPlayer player : Traincraft.proxy.playerList) if (player != null) player.stopPlayer();
 			Traincraft.proxy.playerList.clear();
 		}
 		if(mc.theWorld != null && mc.theWorld.playerEntities != null) {

--- a/src/main/java/train/client/gui/GuiJukebox.java
+++ b/src/main/java/train/client/gui/GuiJukebox.java
@@ -198,7 +198,7 @@ public class GuiJukebox extends GuiScreen {
 	protected void actionPerformed(GuiButton button) {
 		if (button.id == 0) {
 			if (streamTextBox.getText() != null && streamTextBox.getText().length() > 0) {
-				if ((!jukebox.isPlaying())) {
+				if (!jukebox.isPlaying() && (jukebox.player == null || !jukebox.player.isPlaying())) {
 					if (this.streamTextBox.getText().toLowerCase().contains(".m3u")) {
 						this.jukebox.streamURL = takeFirstEntryFromM3U(this.streamTextBox.getText());
 					}
@@ -342,7 +342,7 @@ public class GuiJukebox extends GuiScreen {
 			BufferedReader i = new BufferedReader(new InputStreamReader(con.getInputStream()));
 			String mp3;
 			while ((mp3 = i.readLine()) != null) {
-				if (!mp3.startsWith("#")) {
+				if (!mp3.startsWith("#") && !mp3.replaceAll(" ", "").isEmpty()) {
 					break;
 				}
 			}

--- a/src/main/java/train/common/core/CommonProxy.java
+++ b/src/main/java/train/common/core/CommonProxy.java
@@ -27,7 +27,7 @@ import train.common.api.LiquidTank;
 import train.common.api.Tender;
 import train.common.containers.*;
 import train.common.core.handlers.*;
-import train.common.core.util.MP3Player;
+import train.common.core.util.ReplacementStreamPlayer;
 import train.common.entity.digger.EntityRotativeDigger;
 import train.common.entity.rollingStock.EntityJukeBoxCart;
 import train.common.entity.rollingStock.EntityTracksBuilder;
@@ -60,7 +60,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CommonProxy implements IGuiHandler {
-	public static List<MP3Player> playerList = new ArrayList<MP3Player>();
+	public static List<ReplacementStreamPlayer> playerList = new ArrayList<ReplacementStreamPlayer>();
 	public static boolean debug = false;
 
 	public void throwAlphaException() {
@@ -309,8 +309,8 @@ public class CommonProxy implements IGuiHandler {
 	public void registerVillagerSkin(int villagerId, String textureName) {}
 
 	public static void killAllStreams() {
-		for (MP3Player p : playerList) {
-			p.stop();
+		for (ReplacementStreamPlayer p : playerList) {
+			p.stopPlayer();
 		}
 	}
 

--- a/src/main/java/train/common/core/handlers/WorldEvents.java
+++ b/src/main/java/train/common/core/handlers/WorldEvents.java
@@ -76,7 +76,7 @@ public class WorldEvents{
 	public void chunkUnloadEvent(ChunkEvent.Unload event){
 		for(Object o : event.getChunk().entityLists){
 			if (o instanceof EntityJukeBoxCart){
-				((EntityJukeBoxCart) o).player.setVolume(0);
+				((EntityJukeBoxCart) o).player.setGain(0);
 			}
 		}
 	}

--- a/src/main/java/train/common/core/util/ReplacementStreamPlayer.java
+++ b/src/main/java/train/common/core/util/ReplacementStreamPlayer.java
@@ -1,0 +1,165 @@
+package train.common.core.util;
+
+import com.goxr3plus.streamplayer.stream.StreamPlayer;
+import com.goxr3plus.streamplayer.stream.StreamPlayerEvent;
+import com.goxr3plus.streamplayer.stream.StreamPlayerException;
+import com.goxr3plus.streamplayer.stream.StreamPlayerListener;
+import train.common.entity.rollingStock.EntityJukeBoxCart;
+
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.UnsupportedAudioFileException;
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author broscolotos
+ */
+public class ReplacementStreamPlayer extends StreamPlayer implements StreamPlayerListener {
+
+    private EntityJukeBoxCart source = null;
+
+    static {
+        Logger.getLogger("com.goxr3plus.streamplayer").setLevel(Level.OFF);
+    }
+
+    private String audioSource;
+
+    private AudioInputStream getSafeAudioInputStream(File file) throws UnsupportedAudioFileException, IOException {
+        String name = file.getName().toLowerCase();
+        try {
+            if (name.endsWith(".ogg")) {
+                return new javazoom.spi.vorbis.sampled.file.VorbisAudioFileReader().getAudioInputStream(file);
+            } else if (name.endsWith(".mp3")) {
+                return new javazoom.spi.mpeg.sampled.file.MpegAudioFileReader().getAudioInputStream(file);
+            } else if (name.endsWith(".flac")) {
+                return new org.jflac.sound.spi.FlacAudioFileReader().getAudioInputStream(file);
+            }
+        } catch (Throwable t) {
+            System.err.println("[ReplacementStreamPlayer] Explicit file reader failed for " + name + ", falling back to AudioSystem...");
+        }
+        return AudioSystem.getAudioInputStream(file);
+    }
+
+    private AudioInputStream getSafeAudioInputStream(InputStream inputStream) throws UnsupportedAudioFileException, IOException {
+        // We must wrap in a BufferedInputStream that supports mark/reset so readers can test the header
+        InputStream streamToUse = inputStream.markSupported() ? inputStream : new BufferedInputStream(inputStream);
+        streamToUse.mark(1024 * 1024); // Mark 1MB buffer safely
+
+        // Try Vorbis/Ogg
+        try {
+            return new javazoom.spi.vorbis.sampled.file.VorbisAudioFileReader().getAudioInputStream(streamToUse);
+        } catch (Throwable ignored) {
+            streamToUse.reset();
+        }
+
+        // Try MP3
+        try {
+            return new javazoom.spi.mpeg.sampled.file.MpegAudioFileReader().getAudioInputStream(streamToUse);
+        } catch (Throwable ignored) {
+            streamToUse.reset();
+        }
+
+        // Try Flac
+        try {
+            return new org.jflac.sound.spi.FlacAudioFileReader().getAudioInputStream(streamToUse);
+        } catch (Throwable ignored) {
+            streamToUse.reset();
+        }
+
+        // Fallback to standard JVM system formats (WAV, AIFF, AU)
+        return AudioSystem.getAudioInputStream(streamToUse);
+    }
+
+    @Override
+    public void open(File file) throws StreamPlayerException {
+        try {
+            AudioInputStream safeStream = getSafeAudioInputStream(file);
+            super.open(safeStream);
+        } catch (UnsupportedAudioFileException | IOException e) {
+            System.out.println("Unsupported audio source from " + file);
+        }
+    }
+
+    @Override
+    public void open(InputStream stream) throws StreamPlayerException {
+        try {
+            AudioInputStream safeStream = getSafeAudioInputStream(stream);
+            super.open(safeStream);
+        } catch (UnsupportedAudioFileException | IOException e) {
+            System.out.println("Unsupported audio source from " + stream);
+        }
+    }
+
+    void start() {
+        try {
+            addStreamPlayerListener(this);
+            try {
+                URL url = new URL(audioSource);
+                HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                connection.setConnectTimeout(5000);
+                connection.setReadTimeout(5000);
+                connection.setRequestProperty("User-Agent", "Mozilla/5.0");
+
+                InputStream raw = connection.getInputStream();
+                BufferedInputStream buffered = new BufferedInputStream(raw);
+
+                open(buffered);
+            } catch (IOException e) {
+                open(new File(audioSource));
+            }
+            play();
+
+        } catch (StreamPlayerException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public synchronized void stopPlayer() {
+        try {
+            removeStreamPlayerListener(this);
+            stop();
+
+            System.out.println("[ReplacementStreamPlayer] Stream stopped and background thread released successfully.");
+        } catch (Exception e) {
+            System.err.println("[ReplacementStreamPlayer] Error during stop: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void opened(Object dataSource, Map<String, Object> properties) { }
+
+    @Override
+    public void progress(int nEncodedBytes, long microsecondPosition, byte[] pcmData, Map<String, Object> properties) {
+        if (this.source.isDead || !this.source.isPlaying) {
+            stopPlayer();
+        }
+    }
+
+
+    @Override
+    public void statusUpdated(StreamPlayerEvent event) { }
+
+    /**
+     * Creates a new StreamPlayer. Threaded boolean is mostly used for something that could take a stream, such as the
+     * jukebox cart. That said, if you want a thread, then thread :)
+     * @param audioFileName
+     * @param threaded
+     */
+    public ReplacementStreamPlayer(String audioFileName, EntityJukeBoxCart cart,  boolean threaded) {
+        this.audioSource = audioFileName;
+        this.source = cart;
+        if (threaded) {
+            Thread networkThread = new Thread(this::start, "StreamPlayer-Network-Worker");
+            networkThread.setDaemon(true);
+            networkThread.start();
+        } else {
+            start();
+        }
+    }
+
+}

--- a/src/main/java/train/common/entity/rollingStock/EntityJukeBoxCart.java
+++ b/src/main/java/train/common/entity/rollingStock/EntityJukeBoxCart.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.SoundCategory;
 import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
@@ -13,7 +14,7 @@ import net.minecraft.world.World;
 import train.common.Traincraft;
 import train.common.adminbook.ServerLogger;
 import train.common.api.EntityRollingStock;
-import train.common.core.util.MP3Player;
+import train.common.core.util.ReplacementStreamPlayer;
 import train.common.enums.LockoutGroup;
 import train.common.library.GuiIDs;
 
@@ -24,7 +25,7 @@ public class EntityJukeBoxCart extends EntityRollingStock {
 	public String streamURL = "";
 	private Side side;
 	public float volume = 1.0f;
-	public MP3Player player;
+	public ReplacementStreamPlayer player;
 
 	public EntityJukeBoxCart(World world)
 	{
@@ -90,12 +91,12 @@ public class EntityJukeBoxCart extends EntityRollingStock {
 				float vol = (float) getDistanceSq(Minecraft.getMinecraft().thePlayer.posX,
 						Minecraft.getMinecraft().thePlayer.posY, Minecraft.getMinecraft().thePlayer.posZ);
 				if (vol >= (volume * 1000.0F)) {
-					this.player.setVolume(0.0F);
+					this.player.setGain(0);
 				} else {
 					float v2 = 10000.0F / vol / 100.0F;
 //					System.out.println(vol);
 					if (v2 > 1.0F) {
-						this.player.setVolume(volume);
+						this.player.setGain(volume * Traincraft.proxy.getJukeboxVolume());
 					} else {
 						float v1 = 1.0f - volume;
 						if (v2 - v1 > 0) {
@@ -103,11 +104,21 @@ public class EntityJukeBoxCart extends EntityRollingStock {
 						} else {
 							v2 = 0.0f;
 						}
-						this.player.setVolume(v2);
+						this.player.setGain(v2 * Traincraft.proxy.getJukeboxVolume());
 					}
 				}
 				if (vol == 0) {
 					this.invalidate();
+				}
+				if (this.isPlaying && this.player.getGainValue() != 0) {
+					if (!Minecraft.getMinecraft().thePlayer.getEntityData().hasKey("MusicVolume")) {
+						Minecraft.getMinecraft().thePlayer.getEntityData().setFloat("MusicVolume", Minecraft.getMinecraft().gameSettings.getSoundLevel(SoundCategory.MUSIC));
+						Minecraft.getMinecraft().gameSettings.setSoundLevel(SoundCategory.MUSIC, 0);
+					}
+				}
+				else if (Minecraft.getMinecraft().thePlayer.getEntityData().hasKey("MusicVolume")) {
+					Minecraft.getMinecraft().gameSettings.setSoundLevel(SoundCategory.MUSIC, Minecraft.getMinecraft().thePlayer.getEntityData().getFloat("MusicVolume"));
+					Minecraft.getMinecraft().thePlayer.getEntityData().removeTag("MusicVolume");
 				}
 				if (this.isPlaying && rand.nextInt(5) == 0 && (this.player != null && this.player.isPlaying())) {
 					int random2 = rand.nextInt(24) + 1;
@@ -141,8 +152,8 @@ public class EntityJukeBoxCart extends EntityRollingStock {
 		if (!this.isPlaying) {
 			this.isPlaying = true;
 			if (side == Side.CLIENT) {
-				this.player = new MP3Player(this.streamURL, this.worldObj, this.getEntityId());
-				player.setVolume(0);
+				this.player = new ReplacementStreamPlayer(this.streamURL, this, true);
+				player.setGain(0);
 				Traincraft.proxy.playerList.add(this.player);
 			}
 		}
@@ -155,7 +166,7 @@ public class EntityJukeBoxCart extends EntityRollingStock {
 		if (this.isPlaying) {
 			this.isPlaying = false;
 			if (side == Side.CLIENT && this.player != null) {
-				this.player.stop();
+				this.player.stopPlayer();
 				Traincraft.proxy.playerList.remove(this.player);
 			}
 		}


### PR DESCRIPTION
 - Migrated the Jukebox cart to a new audio player using goxr3plus.Streamplayer. The new player fixes audio streams not responding to game volume.
 - Added audio ducking for the vanilla music. This way they wont clash. As soon as no streams are active the Minecraft music volume will be set back to what it was.
 - Added support for local files (will only work properly in SP)
Note: This might also fix the Jukebox cart just randomly playing at full volume, not certain. The secondary reason this was done is for the Defect Detector developed by 02skaplan. The previous system didn't respond to volume adjustments. The old system is still there for now so if this is somehow worse we can revert.

 - Added the ability to filter out models from rendering within a BOBRollingStockModel. This is mostly useful for things from TCModern where you might have high-poly interiors that can be skipped when outside of the train.
