### PR TITLE
Gradle Timeout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ buildscript {
 apply plugin: 'forge'
 apply plugin: 'idea'
 
+System.setProperty("sun.net.client.defaultConnectTimeout", "5000") //5 seconds to connect
+System.setProperty("sun.net.client.defaultReadTimeout", "10000") //10 seconds to read
+
 sourceCompatibility = targetCompatibility = "1.8"
 compileJava { sourceCompatibility = targetCompatibility = "1.8" }
 
@@ -52,14 +55,14 @@ minecraft {
 
 repositories {
     maven {
+        url "https://jitpack.io"
+    }
+    maven {
         name "ChickenBones"
         url "http://chickenbones.net/maven/"
     }
    maven {
         url = "http://maven.cil.li/"
-    }
-    maven {
-        url "https://jitpack.io"
     }
 }
 


### PR DESCRIPTION
 - added a timeout for when trying to get a mod from a maven repo, and re-ordered the repos. This prevents the build.gradle of addon packs who depend on the project directly, ie TCModern, from timing out.